### PR TITLE
Standardise encoders

### DIFF
--- a/wombat/src/main/cpp/utils/Encoder.cpp
+++ b/wombat/src/main/cpp/utils/Encoder.cpp
@@ -87,12 +87,18 @@ double wom::utils::CANSparkMaxEncoder::GetEncoderTickVelocity() const {
   return _encoder.GetVelocity() * GetEncoderTicksPerRotation() / 60;
 }
 
-wom::utils::TalonFXEncoder::TalonFXEncoder(
-    ctre::phoenix::motorcontrol::can::TalonFX* controller, double reduction)
-    : wom::utils::Encoder(2048, reduction, 0), _controller(controller) {
-  controller->ConfigSelectedFeedbackSensor(
-      ctre::phoenix::motorcontrol::TalonFXFeedbackDevice::IntegratedSensor);
+double utils::CANSparkMaxEncoder::GetPosition() const {
+  return _encoder.GetPosition();
 }
+
+double utils::CANSparkMaxEncoder::GetVelocity() const {
+  return _encoder.GetVelocity();
+}
+
+utils::TalonFXEncoder::TalonFXEncoder(ctre::phoenix::motorcontrol::can::TalonFX *controller, double reduction)
+  : utils::Encoder(2048, reduction, 0), _controller(controller) {
+    controller->ConfigSelectedFeedbackSensor(ctre::phoenix::motorcontrol::TalonFXFeedbackDevice::IntegratedSensor);
+  }
 
 double wom::utils::TalonFXEncoder::GetEncoderRawTicks() const {
   return _controller->GetSelectedSensorPosition();

--- a/wombat/src/main/include/subsystems/Arm.h
+++ b/wombat/src/main/include/subsystems/Arm.h
@@ -24,7 +24,7 @@ struct ArmConfig {
 
   wom::utils::Gearbox leftGearbox;
   wom::utils::Gearbox rightGearbox;
-  rev::SparkMaxRelativeEncoder armEncoder;
+  wom::utils::CANSparkMaxEncoder armEncoder;
   wom::utils::PIDConfig<units::radian, units::volt> pidConfig;
   wom::utils::PIDConfig<units::radians_per_second, units::volt> velocityConfig;
 

--- a/wombat/src/main/include/subsystems/Elevator.h
+++ b/wombat/src/main/include/subsystems/Elevator.h
@@ -22,20 +22,20 @@ namespace wom {
 namespace subsystems {
 enum class ElevatorState { kIdle, kPID, kManual, kVelocity };
 
-struct ElevatorConfig {
-  std::string path;
-  wom::utils::Gearbox leftGearbox;
-  wom::utils::Gearbox rightGearbox;
-  rev::SparkMaxRelativeEncoder elevatorEncoder;
-  frc::DigitalInput* topSensor;
-  frc::DigitalInput* bottomSensor;
-  units::meter_t radius;
-  units::kilogram_t mass;
-  units::meter_t maxHeight;
-  units::meter_t minHeight;
-  units::meter_t initialHeight;
-  wom::utils::PIDConfig<units::meter, units::volt> pid;
-  wom::utils::PIDConfig<units::meters_per_second, units::volt> velocityPID;
+  struct ElevatorConfig {
+    std::string path;
+    wom::utils::Gearbox leftGearbox;
+    wom::utils::Gearbox rightGearbox;
+    wom::utils::CANSparkMaxEncoder elevatorEncoder;
+    frc::DigitalInput *topSensor;
+    frc::DigitalInput *bottomSensor;
+    units::meter_t radius;
+    units::kilogram_t mass;
+    units::meter_t maxHeight;
+    units::meter_t minHeight;
+    units::meter_t initialHeight;
+    wom::utils::PIDConfig<units::meter, units::volt> pid;
+    wom::utils::PIDConfig<units::meters_per_second, units::volt> velocityPID;
 
   void WriteNT(std::shared_ptr<nt::NetworkTable> table);
 };

--- a/wombat/src/main/include/utils/Encoder.h
+++ b/wombat/src/main/include/utils/Encoder.h
@@ -51,8 +51,11 @@ class DigitalEncoder : public Encoder {
       : Encoder(ticksPerRotation, reduction, 0),
         _nativeEncoder(channelA, channelB) {}
 
-  double GetEncoderRawTicks() const override;
-  double GetEncoderTickVelocity() const override;
+    double GetEncoderRawTicks() const override;
+    double GetEncoderTickVelocity() const override;
+    
+    double GetPosition() const;
+    double GetVelocity() const;
 
  private:
   frc::Encoder _nativeEncoder;
@@ -64,13 +67,16 @@ class CANSparkMaxEncoder : public Encoder {
   explicit CANSparkMaxEncoder(rev::CANSparkMax* controller,
                               double reduction = 1);
 
-  double GetEncoderRawTicks() const override;
-  double GetEncoderTickVelocity() const override;
+    double GetEncoderRawTicks() const override;
+    double GetEncoderTickVelocity() const override;
+    
+    double GetPosition() const;
+    double GetVelocity() const;
 
- protected:
-  rev::SparkMaxRelativeEncoder _encoder;
-  friend class SimCANSparkMaxEncoder;
-};
+   protected:
+    rev::SparkMaxRelativeEncoder _encoder;
+    friend class SimCANSparkMaxEncoder;
+  };
 
 class TalonFXEncoder : public Encoder {
  public:


### PR DESCRIPTION
**What this PR does**
Standardize encoder usage by calling all encoders through wombat Encoder abstractions instead of the frc class.

**What does it fix/add?**
Should fix https://github.com/CurtinFRC/2024-Crescendo/issues/47
